### PR TITLE
做了优化：

### DIFF
--- a/src/com/qbb/build/BuildJsonForDubbo.java
+++ b/src/com/qbb/build/BuildJsonForDubbo.java
@@ -107,7 +107,7 @@ public class BuildJsonForDubbo{
         if(psiMethodTarget!=null){
             try {
                 // 获得响应
-                yapiDubboDTO.setResponse(BuildJsonForYapi.getResponse(project,psiMethodTarget.getReturnType()));
+                yapiDubboDTO.setResponse(BuildJsonForYapi.getResponse(project,psiMethodTarget.getReturnType(), null));
             } catch (JSONException e1) {
                 e1.printStackTrace();
             }

--- a/src/com/qbb/build/BuildJsonForYapi.java
+++ b/src/com/qbb/build/BuildJsonForYapi.java
@@ -56,7 +56,7 @@ public class BuildJsonForYapi{
      * @param e
      * @return
      */
-    public ArrayList<YapiApiDTO> actionPerformedList(AnActionEvent e,String attachUpload){
+    public ArrayList<YapiApiDTO> actionPerformedList(AnActionEvent e,String attachUpload, String returnClass){
         Editor editor = (Editor) e.getDataContext().getData(CommonDataKeys.EDITOR);
         PsiFile psiFile = (PsiFile) e.getDataContext().getData(CommonDataKeys.PSI_FILE);
         String selectedText=e.getRequiredData(CommonDataKeys.EDITOR).getSelectionModel().getSelectedText();
@@ -84,7 +84,7 @@ public class BuildJsonForYapi{
             for(PsiMethod psiMethodTarget:psiMethods) {
                 //去除私有方法
                 if(!psiMethodTarget.getModifierList().hasModifierProperty("private")) {
-                    YapiApiDTO yapiApiDTO=actionPerformed(selectedClass, psiMethodTarget, project, psiFile,attachUpload);
+                    YapiApiDTO yapiApiDTO=actionPerformed(selectedClass, psiMethodTarget, project, psiFile,attachUpload, returnClass);
                     if(Objects.isNull(yapiApiDTO.getMenu())){
                         yapiApiDTO.setMenu(classMenu);
                     }
@@ -102,7 +102,7 @@ public class BuildJsonForYapi{
                 }
             }
             if(Objects.nonNull(psiMethodTarget)) {
-                YapiApiDTO yapiApiDTO= actionPerformed(selectedClass, psiMethodTarget, project, psiFile,attachUpload);
+                YapiApiDTO yapiApiDTO= actionPerformed(selectedClass, psiMethodTarget, project, psiFile,attachUpload, returnClass);
                 if(Objects.isNull(yapiApiDTO.getMenu())){
                     yapiApiDTO.setMenu(classMenu);
                 }
@@ -117,7 +117,7 @@ public class BuildJsonForYapi{
     }
 
 
-    public static YapiApiDTO actionPerformed(PsiClass selectedClass,PsiMethod psiMethodTarget,Project project,PsiFile psiFile,String attachUpload) {
+    public static YapiApiDTO actionPerformed(PsiClass selectedClass,PsiMethod psiMethodTarget,Project project,PsiFile psiFile,String attachUpload, String returnClass) {
         YapiApiDTO yapiApiDTO=new YapiApiDTO();
         // 获得路径
         StringBuilder path=new StringBuilder();
@@ -240,7 +240,7 @@ public class BuildJsonForYapi{
             // 先清空之前的文件路径
             filePaths.clear();
             // 生成响应参数
-            yapiApiDTO.setResponse(getResponse(project,psiMethodTarget.getReturnType()));
+            yapiApiDTO.setResponse(getResponse(project,psiMethodTarget.getReturnType(), returnClass));
             Set<String> codeSet = new HashSet<>();
             Long time= System.currentTimeMillis();
             String responseFileName="/response_"+time+".zip";
@@ -336,7 +336,7 @@ public class BuildJsonForYapi{
                 }
                 PsiAnnotation psiAnnotation= PsiAnnotationSearchUtil.findAnnotation(psiParameter,SpringMVCConstant.RequestBody);
                 if(psiAnnotation!=null){
-                    yapiApiDTO.setRequestBody(getResponse(project,psiParameter.getType()));
+                    yapiApiDTO.setRequestBody(getResponse(project,psiParameter.getType(), null));
                 }else{
                     psiAnnotation= PsiAnnotationSearchUtil.findAnnotation(psiParameter,SpringMVCConstant.RequestParam);
                     YapiHeaderDTO yapiHeaderDTO=null;
@@ -398,7 +398,7 @@ public class BuildJsonForYapi{
                                             yapiQueryDTO.setExample(NormalTypes.normalTypes.get(psiParameter.getType().getPresentableText()).toString());
                                         }
                                     }else{
-                                        yapiApiDTO.setRequestBody(getResponse(project,psiParameter.getType()));
+                                        yapiApiDTO.setRequestBody(getResponse(project,psiParameter.getType(), null));
                                     }
 
                                 }
@@ -426,7 +426,7 @@ public class BuildJsonForYapi{
                                     yapiQueryDTO.setExample(NormalTypes.normalTypes.get(psiParameter.getType().getPresentableText()).toString());
                                 }
                             }else{
-                                yapiApiDTO.setRequestBody(getResponse(project,psiParameter.getType()));
+                                yapiApiDTO.setRequestBody(getResponse(project,psiParameter.getType(), null));
                             }
                         }
                         if(yapiHeaderDTO!=null){
@@ -539,12 +539,34 @@ public class BuildJsonForYapi{
      * @author: chengsheng@qbb6.com
      * @date: 2019/2/19
      */ 
-    public static String getResponse(Project project,PsiType psiType) throws JSONException{
-        return getPojoJson(project, psiType);
+    public static String getResponse(Project project,PsiType psiType, String returnClass) throws JSONException{
+        String response = null;
+        /** 最外层的包装类只会有一个泛型对应接口返回值 */
+        if (!StringUtil.isNullOrEmpty(returnClass) && !psiType.getCanonicalText().split("<")[0].equals(returnClass)) {
+            PsiClass psiClass = JavaPsiFacade.getInstance(project).findClass(returnClass, GlobalSearchScope.allScope(project));
+            KV result = new KV();
+            List<String> requiredList=new ArrayList<>();
+            KV kvObject = getFields(psiClass, project,null,null,requiredList);
+            for (PsiField field : psiClass.getAllFields()) {
+                if (NormalTypes.genericList.contains(field.getType().getPresentableText())) {
+                    KV child = getPojoJson(project, psiType);
+                    kvObject.set(field.getName(), child);
+                }
+            }
+            result.set("type", "object");
+            result.set("title", psiClass.getName());
+            result.set("required",requiredList);
+            result.set("description", psiClass.getQualifiedName());
+            result.set("properties", kvObject);
+            response = result.toPrettyJson();
+        } else {
+            response = getPojoJson(project, psiType).toPrettyJson();
+        }
+        return response;
     }
 
 
-    public static String getPojoJson(Project project,PsiType psiType) throws JSONException{
+    public static KV getPojoJson(Project project,PsiType psiType) throws JSONException{
         if(psiType instanceof PsiPrimitiveType){
             //如果是基本类型
             KV kvClass=KV.create();
@@ -582,8 +604,7 @@ public class BuildJsonForYapi{
             result.set("title", psiType.getPresentableText());
             result.set("description", psiType.getPresentableText());
             result.set("items", listKv);
-            String json = result.toPrettyJson();
-            return json;
+            return result;
         }else if(psiType.getPresentableText().startsWith("Set")){
             String[] types=psiType.getCanonicalText().split("<");
             KV listKv=new KV();
@@ -613,8 +634,7 @@ public class BuildJsonForYapi{
             result.set("title", psiType.getPresentableText());
             result.set("description", psiType.getPresentableText());
             result.set("items", listKv);
-            String json = result.toPrettyJson();
-            return json;
+            return result;
         }else if(psiType.getPresentableText().startsWith("Map")){
             HashMap hashMapChild=new HashMap();
             String[] types=psiType.getCanonicalText().split("<");
@@ -628,8 +648,7 @@ public class BuildJsonForYapi{
             result.set("title", psiType.getPresentableText());
             result.set("description", psiType.getPresentableText());
             result.set("properties", hashMapChild);
-            String json = result.toPrettyJson();
-            return json;
+            return result;
         }else if(NormalTypes.collectTypes.containsKey(psiType.getPresentableText())){
             //如果是集合类型
             KV kvClass=KV.create();
@@ -650,8 +669,7 @@ public class BuildJsonForYapi{
                 }
                 result.set("description", (psiType.getPresentableText()+" :"+psiClassChild.getName()).trim());
                 result.set("properties", kvObject);
-                String json = result.toPrettyJson();
-                return json;
+                return result;
             }else{
                 PsiClass psiClassChild = JavaPsiFacade.getInstance(project).findClass(psiType.getCanonicalText(), GlobalSearchScope.allScope(project));
                 KV result = new KV();
@@ -666,8 +684,7 @@ public class BuildJsonForYapi{
                 result.set("title", psiType.getPresentableText());
                 result.set("description", (psiType.getPresentableText()+" :"+psiClassChild.getName()).trim());
                 result.set("properties", kvObject);
-                String json = result.toPrettyJson();
-                return json;
+                return result;
             }
         }
         return null;

--- a/src/com/qbb/build/BuildJsonForYapi.java
+++ b/src/com/qbb/build/BuildJsonForYapi.java
@@ -771,8 +771,20 @@ public class BuildJsonForYapi{
                 }
                 kv.set(name, jsonObject);
             }else if(!(type instanceof PsiArrayType)&&((PsiClassReferenceType) type).resolve().isEnum()) {
+                PsiClass psiClass = JavaPsiFacade.getInstance(project).findClass(type.getCanonicalText(), GlobalSearchScope.allScope(project));
                 JsonObject jsonObject=new JsonObject();
-                jsonObject.addProperty("type","enum");
+                jsonObject.addProperty("type","integer");
+                int enumIndex = 0;
+                for (PsiField field1 : psiClass.getFields()) {
+                    if(field1.getDocComment()!=null) {
+                        remark += " \r\n" + enumIndex + ":" + field1.getName() + " ";
+                        remark += DesUtil.getFiledDesc(field1.getDocComment());
+                        //获得link 备注
+                        remark = DesUtil.getLinkRemark(remark, project, field1);
+                        getFilePath(project,filePaths,DesUtil.getFieldLinks(project,field1));
+                        enumIndex++;
+                    }
+                }
                 if(!Strings.isNullOrEmpty(remark)) {
                     jsonObject.addProperty("description", remark);
                 }

--- a/src/com/qbb/build/NormalTypes.java
+++ b/src/com/qbb/build/NormalTypes.java
@@ -1,10 +1,10 @@
 package com.qbb.build;
 
+import io.netty.util.internal.StringUtil;
 import org.jetbrains.annotations.NonNls;
 
 import java.sql.Timestamp;
 import java.text.SimpleDateFormat;
-import java.time.LocalDateTime;
 import java.util.*;
 
 /**
@@ -16,7 +16,7 @@ import java.util.*;
 public class NormalTypes {
 
     @NonNls
-    public static final Map<String, Object> normalTypes = new HashMap<>();
+    public static final Map<String, String> normalTypes = new HashMap<>();
 
     public static final Map<String,Object> noramlTypesPackages=new HashMap<>();
 
@@ -30,31 +30,31 @@ public class NormalTypes {
 
 
     static {
-        normalTypes.put("int",1);
-        normalTypes.put("boolean",false);
-        normalTypes.put("byte",1);
-        normalTypes.put("short",1);
-        normalTypes.put("long",1L);
-        normalTypes.put("float",1.0F);
-        normalTypes.put("double",1.0D);
-        normalTypes.put("char",'a');
-        normalTypes.put("Boolean", false);
-        normalTypes.put("Byte", 0);
-        normalTypes.put("Short", Short.valueOf((short) 0));
-        normalTypes.put("Integer", 0);
-        normalTypes.put("Long", 0L);
-        normalTypes.put("Float", 0.0F);
-        normalTypes.put("Double", 0.0D);
-        normalTypes.put("String", "String");
-        normalTypes.put("Date", new SimpleDateFormat("YYYY-MM-dd HH:mm:ss").format(new Date()));
-        normalTypes.put("BigDecimal",0.111111);
-        normalTypes.put("LocalDate", new SimpleDateFormat("YYYY-MM-dd").format(new Date()));
-        normalTypes.put("LocalTime", new SimpleDateFormat("HH:mm:ss").format(new Date()));
-        normalTypes.put("LocalDateTime", new SimpleDateFormat("YYYY-MM-dd HH:mm:ss").format(new Date()));
-        normalTypes.put("Timestamp",new Timestamp(System.currentTimeMillis()));
-        collectTypes.put("HashMap","HashMap");
-        collectTypes.put("Map","Map");
-        collectTypes.put("LinkedHashMap","LinkedHashMap");
+        normalTypes.put("int","integer");
+        normalTypes.put("boolean","boolean");
+        normalTypes.put("byte","string");
+        normalTypes.put("short","integer");
+        normalTypes.put("long","integer");
+        normalTypes.put("float","number");
+        normalTypes.put("double","number");
+        normalTypes.put("char","string");
+        normalTypes.put("Boolean", "boolean");
+        normalTypes.put("Byte", "string");
+        normalTypes.put("Short", "integer");
+        normalTypes.put("Integer", "integer");
+        normalTypes.put("Long", "integer");
+        normalTypes.put("Float", "number");
+        normalTypes.put("Double", "number");
+        normalTypes.put("String", "string");
+        normalTypes.put("Date", "string");
+        normalTypes.put("BigDecimal","number");
+        normalTypes.put("LocalDate", "string");
+        normalTypes.put("LocalTime", "string");
+        normalTypes.put("LocalDateTime", "string");
+        normalTypes.put("Timestamp","integer");
+        collectTypes.put("HashMap","object");
+        collectTypes.put("Map","object");
+        collectTypes.put("LinkedHashMap","object");
 
         genericList.add("T");
         genericList.add("E");
@@ -97,6 +97,11 @@ public class NormalTypes {
 
 
     public static boolean isNormalType(String typeName) {
-        return normalTypes.containsKey(typeName);
+        return normalTypes.containsKey(typeName) || noramlTypesPackages.containsKey(typeName);
+    }
+
+    public static String getYapiType(String typeName) {
+        String type = normalTypes.get(typeName);
+        return StringUtil.isNullOrEmpty(type)?typeName:type;
     }
 }

--- a/src/com/qbb/interaction/UploadToYapi.java
+++ b/src/com/qbb/interaction/UploadToYapi.java
@@ -49,6 +49,7 @@ public class UploadToYapi extends AnAction {
         String projectId=null;
         String yapiUrl=null;
         String projectType=null;
+        String returnClass=null;
         String attachUpload=null;
         // 获取配置
         try {
@@ -64,6 +65,7 @@ public class UploadToYapi extends AnAction {
                         projectId = projectConfig.split(moduleList[i]+"\\.Id\">")[1].split("</")[0];
                         yapiUrl = projectConfig.split(moduleList[i]+"\\.Url\">")[1].split("</")[0];
                         projectType = projectConfig.split(moduleList[i]+"\\.Type\">")[1].split("</")[0];
+                        returnClass = projectConfig.split(moduleList[i]+"\\.Class\">")[1].split("</")[0];
                         String[] attachs = projectConfig.split(moduleList[i]+"\\.AttachUploadUrl\">");
                         if (attachs.length > 1) {
                             attachUpload = attachs[1].split("</")[0];
@@ -76,6 +78,7 @@ public class UploadToYapi extends AnAction {
                 projectId = projectConfig.split("projectId\">")[1].split("</")[0];
                 yapiUrl = projectConfig.split("yapiUrl\">")[1].split("</")[0];
                 projectType = projectConfig.split("projectType\">")[1].split("</")[0];
+                returnClass = projectConfig.split("returnClass\">")[1].split("</")[0];
                 String[] attachs = projectConfig.split("attachUploadUrl\">");
                 if (attachs.length > 1) {
                     attachUpload = attachs[1].split("</")[0];
@@ -125,7 +128,7 @@ public class UploadToYapi extends AnAction {
             }
         }else if(ProjectTypeConstant.api.equals(projectType)){
             //获得api 需上传的接口列表 参数对象
-            ArrayList<YapiApiDTO> yapiApiDTOS=new BuildJsonForYapi().actionPerformedList(e,attachUpload);
+            ArrayList<YapiApiDTO> yapiApiDTOS=new BuildJsonForYapi().actionPerformedList(e, attachUpload, returnClass);
             if(yapiApiDTOS!=null) {
                 for (YapiApiDTO yapiApiDTO : yapiApiDTOS) {
                     YapiSaveParam yapiSaveParam = new YapiSaveParam(projectToken, yapiApiDTO.getTitle(), yapiApiDTO.getPath(), yapiApiDTO.getParams(), yapiApiDTO.getRequestBody(), yapiApiDTO.getResponse(), Integer.valueOf(projectId), yapiUrl, true, yapiApiDTO.getMethod(), yapiApiDTO.getDesc(), yapiApiDTO.getHeader());

--- a/src/com/qbb/interaction/UploadToYapi.java
+++ b/src/com/qbb/interaction/UploadToYapi.java
@@ -52,7 +52,7 @@ public class UploadToYapi extends AnAction {
         String attachUpload=null;
         // 获取配置
         try {
-            String projectConfig=new String(editor.getProject().getProjectFile().contentsToByteArray(),"utf-8");
+            String projectConfig=new String(editor.getProject().getBaseDir().findFileByRelativePath("src/main/resources/yapi.xml").contentsToByteArray(),"utf-8");
             String[] modules=projectConfig.split("moduleList\">");
             if(modules.length>1){
                 String[] moduleList=modules[1].split("</")[0].split(",");


### PR DESCRIPTION
1、将配置文件从idea目录迁移出来，迁移到src/main/resources 目录下，主要考虑是一般会忽略.idea文件，忽略的原因是避免不同开发者协作是产生额外冲突；
2、未选中类名/方法名的情况下触发上传的，默认上传当前文件中的主类，降低操作成本和学习成本；
3、泛型中包含的类为基础类型的时候，直接将泛型字段作为基础类型；
4、将java中的类型和YAPI的类型做映射，确保一致性，以便mock数据自动生成；