### PR TITLE
添加 基本mock数据

### DIFF
--- a/src/com/qbb/build/BuildJsonForYapi.java
+++ b/src/com/qbb/build/BuildJsonForYapi.java
@@ -30,6 +30,8 @@ import org.codehaus.jettison.json.JSONException;
 
 import java.io.File;
 import java.io.IOException;
+import java.sql.Timestamp;
+import java.text.SimpleDateFormat;
 import java.util.*;
 import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.stream.Collectors;
@@ -772,6 +774,7 @@ public class BuildJsonForYapi{
             if(!Strings.isNullOrEmpty(remark)) {
                 jsonObject.addProperty("description", remark);
             }
+            jsonObject.add("mock",formatMockType(type.getPresentableText()));
             kv.set(name, jsonObject);
         } else {
             //reference Type
@@ -783,6 +786,7 @@ public class BuildJsonForYapi{
                 if(!Strings.isNullOrEmpty(remark)) {
                     jsonObject.addProperty("description", remark);
                 }
+                jsonObject.add("mock",formatMockType(type.getPresentableText()));
                 kv.set(name, jsonObject);
             }else if(!(type instanceof PsiArrayType)&&((PsiClassReferenceType) type).resolve().isEnum()) {
                 JsonObject jsonObject=new JsonObject();
@@ -814,6 +818,7 @@ public class BuildJsonForYapi{
                         kv1.set(KV.by("type", psiClassChild.getName()));
                         kv.set(name, kv1);
                         kv1.set(KV.by("description", (Strings.isNullOrEmpty(remark)?name:remark)));
+                        kv1.set(KV.by("mock", formatMockType(child)));
                     } else {
                         //class type
                         KV kv1 = new KV();
@@ -915,6 +920,86 @@ public class BuildJsonForYapi{
                 kv.set(name,kv1);
             }
         }
+    }
+
+    private static JsonObject formatMockType(String type) {
+        JsonObject mock = new JsonObject();
+        if (type.equals("int")){
+            mock.addProperty("mock", "@integer");
+        }else if (type.equals("boolean")){
+            mock.addProperty("mock", "@boolean");
+        }else if (type.equals("byte")){
+            mock.addProperty("mock", "@byte");
+        }else if (type.equals("short")){
+            mock.addProperty("mock", "@integer");
+        }else if (type.equals("long")){
+            mock.addProperty("mock", "@integer");
+        }else if (type.equals("float")){
+            mock.addProperty("mock", "@float");
+        }else if (type.equals("double")){
+            mock.addProperty("mock", "@float");
+        }else if (type.equals("char")){
+            mock.addProperty("mock", "@char");
+        }else if (type.equals("Boolean")){
+            mock.addProperty("mock", "@boolean");
+        }else if (type.equals("Byte")){
+            mock.addProperty("mock", "@byte");
+        }else if (type.equals("Short")){
+            mock.addProperty("mock", "@integer");
+        }else if (type.equals("Integer")){
+            mock.addProperty("mock", "@integer");
+        }else if (type.equals("Long")){
+            mock.addProperty("mock", "@integer");
+        }else if (type.equals("Float")){
+            mock.addProperty("mock", "@float");
+        }else if (type.equals("Double")){
+            mock.addProperty("mock", "@float");
+        }else if (type.equals("String")){
+            mock.addProperty("mock", "@string");
+        }else if (type.equals("Date")){
+            mock.addProperty("mock", "@timestamp");
+        }else if (type.equals("BigDecimal")){
+            mock.addProperty("mock", "@float");
+        }else if (type.equals("LocalDate")){
+            mock.addProperty("mock", "@timestamp");
+        }else if (type.equals("LocalTime")){
+            mock.addProperty("mock", "@timestamp");
+        }else if (type.equals("LocalDateTime")){
+            mock.addProperty("mock", "@timestamp");
+        }else if (type.equals("Timestamp")){
+            mock.addProperty("mock", "@timestamp");
+        }else if (type.equals("java.lang.Boolean")){
+            mock.addProperty("mock", "@boolean");
+        }else if (type.equals("java.lang.Byte")){
+            mock.addProperty("mock", "@byte");
+        }else if (type.equals("java.lang.Short")){
+            mock.addProperty("mock", "@integer");
+        }else if (type.equals("java.lang.Integer")){
+            mock.addProperty("mock", "@integer");
+        }else if (type.equals("java.lang.Long")){
+            mock.addProperty("mock", "@integer");
+        }else if (type.equals("java.lang.Float")){
+            mock.addProperty("mock", "@float");
+        }else if (type.equals("java.lang.Double")){
+            mock.addProperty("mock", "@float");
+        }else if (type.equals("java.sql.Timestamp")){
+            mock.addProperty("mock", "@timestamp");
+        }else if (type.equals("java.util.Date")){
+            mock.addProperty("mock", "@timestamp");
+        }else if (type.equals("java.lang.String")){
+            mock.addProperty("mock", "@string");
+        }else if (type.equals("java.math.BigDecimal")){
+            mock.addProperty("mock", "@float");
+        }else if (type.equals("java.time.LocalDate")){
+            mock.addProperty("mock", "@timestamp");
+        }else if (type.equals("java.time.LocalTime")){
+            mock.addProperty("mock", "@timestamp");
+        }else if (type.equals("java.time.LocalDateTime")){
+            mock.addProperty("mock", "@timestamp");
+        }else{
+            mock.addProperty("mock", "mock");
+        }
+        return mock;
     }
 
 


### PR DESCRIPTION
添加 基本mock数据，使前端可以方便使用yapi的基本mock功能时不会返回空数据