### PR TITLE
fix:修复win环境下无法获取模块的问题

### DIFF
--- a/src/main/java/com/qbb/interaction/UploadToYapi.java
+++ b/src/main/java/com/qbb/interaction/UploadToYapi.java
@@ -18,6 +18,8 @@ import com.qbb.constant.ProjectTypeConstant;
 import com.qbb.constant.YapiConstant;
 import com.qbb.dto.*;
 import com.qbb.upload.UploadYapi;
+import org.apache.commons.lang3.RegExUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import java.awt.*;
 import java.awt.datatransfer.Clipboard;
@@ -66,7 +68,10 @@ public class UploadToYapi extends AnAction {
                         if (!it.getProjectName().equals(project.getName())) {
                             return false;
                         }
-                        final String str = (File.separator + it.getProjectName() + File.separator) + (it.getModuleName().equals(it.getProjectName()) ? "" : (it.getModuleName() + File.separator));
+                        String str = (File.separator + it.getProjectName() + File.separator) + (it.getModuleName().equals(it.getProjectName()) ? "" : (it.getModuleName() + File.separator));
+                        if (StringUtils.contains(str, "\\")) {
+                            str = RegExUtils.replaceAll(str, "\\\\", "/");
+                        }
                         return virtualFile.contains(str);
                     }).collect(Collectors.toList());
             if (collect.isEmpty()) {


### PR DESCRIPTION
 
![配置1](https://user-images.githubusercontent.com/44609506/232291645-175b918f-126d-47ad-8ea6-e58e939d67f6.png)

 
![问题原因1](https://user-images.githubusercontent.com/44609506/232291652-1c08a72a-7188-4a38-b9a9-f2abfe0f8ffb.png)
![问题原因2高清](https://user-images.githubusercontent.com/44609506/232292529-c817024a-fe2d-459b-b705-84cc6516b5da.png)
 
这段代码在unix系统运行没有问题，但是在winodws系统下运行会匹配不到，应该统一将反斜杠“\“ 处理成 ”/“ 。
处理方法多种多样，这里直接判断一下，如果存在”\“,那么就改成”/“；
**麻烦合并一下，谢谢！**

附上成功后的截图：
 
![成功截图](https://user-images.githubusercontent.com/44609506/232291664-c5a119fc-a090-4a35-81e3-7d2e35f55f4a.png)
